### PR TITLE
add adaptive convergence to Itpack

### DIFF
--- a/SRC/system_of_eqn/linearSOE/itpack/ItpackLinSolver.h
+++ b/SRC/system_of_eqn/linearSOE/itpack/ItpackLinSolver.h
@@ -55,7 +55,7 @@ class ItpackLinSOE;
 class ItpackLinSolver : public LinearSOESolver
 {
  public:
-  ItpackLinSolver(int method, int maxIter = 100, double omega = 1.0);
+  ItpackLinSolver(int method, int maxIter = 100, double omega = 1.0, double zeta = 5e-6);
   ItpackLinSolver();
   virtual ~ItpackLinSolver();
   
@@ -96,6 +96,9 @@ class ItpackLinSolver : public LinearSOESolver
 
   // Parameter for SOR and SSOR fixed omega methods
   double omega;
+
+  // Parameter for convergence criteria
+  double zeta;
 };
 
 #endif


### PR DESCRIPTION
Hi, Michael. 

These are some suggested changes to the implementation:
1. Allow user to specify a starting value `zeta` for `rparm[0]`, which defines the stopping criterion or approximate relative accuracy desired in the final computed solution. 
2. Always adjust `rparm[0]` based on the squared norm of the right-hand side vector. This ensures that the linear solver enforces a stricter tolerance than the equilibrium solution algorithm.
3. Define `iparm[4]` based on whether the `linearSOE` is symmetric or not.